### PR TITLE
Fix bash errors when the versions had differing number of elements.

### DIFF
--- a/check_kernel
+++ b/check_kernel
@@ -43,10 +43,10 @@ compare_versions() {
     fi
     # If one of the version numbers has less elements, assume zero.
     if [ -z "${version1[$i]}" ] ; then
-      {version1[$i]}=0
+      version1[$i]=0
     fi
     if [ -z "${version2[$i]}" ] ; then
-      {version2[$i]}=0
+      version2[$i]=0
     fi
     if [ "${version1[$i]}" -gt "${version2[$i]}" ] ; then
       test "$operator" = "$FIRST_BIGGER"


### PR DESCRIPTION
Without this, I think things were still working, but I was getting this type of output:

```
./check_kernel: line 49: {version2[4]}=0: command not found
./check_kernel: line 51: [: : integer expression expected
./check_kernel: line 55: [: : integer expression expected
./check_kernel: line 49: {version2[5]}=0: command not found
./check_kernel: line 51: [: : integer expression expected
./check_kernel: line 55: [: : integer expression expected
OK - Running kernel: 2.6.32-504.1.3; available kernels:  2.6.32-431.20.3 2.6.32-504 2.6.32-504.1.3.
```

The assignment of these missing values of `0` didn't seem to be working with the curly braces. Removing those makes the assignment work as expected with no warning.