### PR TITLE
added bash pattern substitution to remove a-z and _ from version strings

### DIFF
--- a/check_kernel
+++ b/check_kernel
@@ -48,11 +48,11 @@ compare_versions() {
     if [ -z "${version2[$i]}" ] ; then
       version2[$i]=0
     fi
-    if [ "${version1[$i]}" -gt "${version2[$i]}" ] ; then
+    if [ "${version1[$i]//[_a-zA-Z]}" -gt "${version2[$i]//[_a-zA-Z]}" ] ; then
       test "$operator" = "$FIRST_BIGGER"
       return $?
     fi
-    if [ "${version1[$i]}" -lt "${version2[$i]}" ] ; then
+    if [ "${version1[$i]//[_a-zA-Z]}" -lt "${version2[$i]//[_a-zA-Z]}" ] ; then
       test "$operator" = "$SECOND_BIGGER"
       return $?
     fi


### PR DESCRIPTION
avoid errors like this
```
# bash ~/bin/check_kernel
/root/bin/check_kernel: line 51: [: el7: integer expression expected
/root/bin/check_kernel: line 55: [: el7: integer expression expected
/root/bin/check_kernel: line 51: [: x86_64: integer expression expected
/root/bin/check_kernel: line 55: [: x86_64: integer expression expected
OK - Running kernel: 3.10.0-327.4.4.el7.x86_64; available kernels:  3.10.0-229.20.1.el7 3.10.0-229.4.2.el7 3.10.0-229.7.2.el7 3.10.0-327.3.1.el7 3.10.0-327.4.4.el7.
```