### PR TITLE
Add new options and support for JBOD

### DIFF
--- a/check_megaraid
+++ b/check_megaraid
@@ -15,6 +15,7 @@
 # 2014-08-25 - Onno - Added -NoLog to prevent /MegaSAS.log filling up partition. Thanks to Rogier for bug report.
 # 2016-05-12 - Eduardo - Check whether RAID controller is offline
 # 2017-11-21 - Svamberg - Add new option for skipping if is RAID controller offline
+# 2017-11-21 - Svamberg - Add JBOD to filter for Firmware state
 
 # Only runnable for root
 if [[ $EUID -ne 0 ]]; 
@@ -127,7 +128,7 @@ for ENCLOSURE_ID in `$MEGACLI -PDList -a$ADAPTER -NoLog | grep "Enclosure Device
     else
       PREDICTIVE_FAILURE_REGEX=''
     fi
-    ERRORLINES=`echo "$DISKINFO" | grep 'Count: [1-9]\|Firmware state:' | grep -v "Firmware state: Online\|Firmware state: Hotspare$PREDICTIVE_FAILURE_REGEX"`
+    ERRORLINES=`echo "$DISKINFO" | grep 'Count: [1-9]\|Firmware state:' | grep -v "Firmware state: Online\|Firmware state: JBOD\|Firmware state: Hotspare$PREDICTIVE_FAILURE_REGEX"`
     if [ -n "$ERRORLINES" ] ; then
       NUMBER_OF_MEDIA_AND_OTHER_ERRORS=0
       NUMBER_OF_ERRORLINES=0

--- a/check_megaraid
+++ b/check_megaraid
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Uses MegaCli to check the status of disks attached to an LSI controller.
-# Optional argument: [ --html | --newline ]
+# Optional argument: [ --html | --newline ] [ --skip-offline-check ]
 # Bugs: this check will probably fail if you have more than one adapter in a host.
 # 2013-12-03 - Onno - Created.
 # 2013-12-05 - Onno - Added output format option.
@@ -14,6 +14,7 @@
 # 2014-08-20 - a-nldisr - Get S/N for Fujitsu systems.
 # 2014-08-25 - Onno - Added -NoLog to prevent /MegaSAS.log filling up partition. Thanks to Rogier for bug report.
 # 2016-05-12 - Eduardo - Check whether RAID controller is offline
+# 2017-11-21 - Svamberg - Add new option for skipping if is RAID controller offline
 
 # Only runnable for root
 if [[ $EUID -ne 0 ]]; 
@@ -41,23 +42,30 @@ if [ ! -x "$MEGACLI" ] ; then
   exit $STATE_UNKNOWN
 fi
 
-case "$1" in
-  "--html"|"-h")
-    LINEFEED="<br>"
-    ;;
-  "--newline"|"-n")
-    LINEFEED="\n"
-    ;;
-  *)
-    LINEFEED=" --- "
-esac
+OPT_SKIPOFFLINECHECK="0"
+for i in $@; do
+  case "$i" in
+    "--html"|"-h")
+      LINEFEED="<br>"
+      ;;
+    "--newline"|"-n")
+      LINEFEED="\n"
+      ;;
+    "--skip-offline-check")
+      OPT_SKIPOFFLINECHECK="1"
+      ;;
+    *)
+      LINEFEED=" --- "
+  esac
+done
 
 # Check whether RAID controller is offline
-if dmesg | egrep --silent 'rejecting I/O to offline device' ; then
-  echo 'RAID controller is offline'
-  exit $STATE_CRITICAL
+if [ -z $OPT_SKIPOFFLINECHECK ]; then
+  if dmesg | egrep --silent 'rejecting I/O to offline device' ; then
+    echo 'RAID controller is offline'
+    exit $STATE_CRITICAL
+  fi
 fi
-
 
 # ToDo: iterate over all available adapters. For now, assume there's only one.
 ADAPTER=0

--- a/check_megaraid
+++ b/check_megaraid
@@ -33,7 +33,9 @@ STATE_DEPENDENT=4
 
 # Check if binaries exist.
 /usr/bin/which dmidecode 2>&1 1>/dev/null || exit $STATE_UNKNOWN
-MEGACLI="/opt/MegaRAID/MegaCli/MegaCli64"
+
+MEGACLI=`which megacli` || `which MegaCli64` || "/opt/MegaRAID/MegaCli/MegaCli64"
+
 if [ ! -x "$MEGACLI" ] ; then
   echo "UNKNOWN: File $MEGACLI is not found or not executable."
   exit $STATE_UNKNOWN

--- a/check_megaraid
+++ b/check_megaraid
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Uses MegaCli to check the status of disks attached to an LSI controller.
-# Optional argument: [ --html | --newline ] [ --skip-offline-check ]
+# Optional argument: [ --html | --newline ] [ --skip-offline-check ] [ --disable-other-error-count ]
 # Bugs: this check will probably fail if you have more than one adapter in a host.
 # 2013-12-03 - Onno - Created.
 # 2013-12-05 - Onno - Added output format option.
@@ -16,6 +16,7 @@
 # 2016-05-12 - Eduardo - Check whether RAID controller is offline
 # 2017-11-21 - Svamberg - Add new option for skipping if is RAID controller offline
 # 2017-11-21 - Svamberg - Add JBOD to filter for Firmware state
+# 2017-11-21 - Svamberg - Add option to disable check of Other Error Count
 
 # Only runnable for root
 if [[ $EUID -ne 0 ]]; 

--- a/check_megaraid
+++ b/check_megaraid
@@ -44,6 +44,7 @@ if [ ! -x "$MEGACLI" ] ; then
 fi
 
 OPT_SKIPOFFLINECHECK="0"
+OPT_DISABLEOTHERERRORCOUNT="0"
 for i in $@; do
   case "$i" in
     "--html"|"-h")
@@ -54,6 +55,9 @@ for i in $@; do
       ;;
     "--skip-offline-check")
       OPT_SKIPOFFLINECHECK="1"
+      ;;
+    "--disable-other-error-count")
+      OPT_DISABLEOTHERERRORCOUNT="1"
       ;;
     *)
       LINEFEED=" --- "
@@ -128,7 +132,13 @@ for ENCLOSURE_ID in `$MEGACLI -PDList -a$ADAPTER -NoLog | grep "Enclosure Device
     else
       PREDICTIVE_FAILURE_REGEX=''
     fi
-    ERRORLINES=`echo "$DISKINFO" | grep 'Count: [1-9]\|Firmware state:' | grep -v "Firmware state: Online\|Firmware state: JBOD\|Firmware state: Hotspare$PREDICTIVE_FAILURE_REGEX"`
+
+    if [ "$OPT_DISABLEOTHERERRORCOUNT" -eq "0" ] ; then
+      ERRORLINES=`echo "$DISKINFO" | grep 'Count: [1-9]\|Firmware state:' | grep -v "Firmware state: Online\|Firmware state: JBOD\|Firmware state: Hotspare$PREDICTIVE_FAILURE_REGEX"`
+    else
+      ERRORLINES=`echo "$DISKINFO" | grep 'Count: [1-9]\|Firmware state:' | grep -v "Firmware state: Online\|Firmware state: JBOD\|Firmware state: Hotspare$PREDICTIVE_FAILURE_REGEX\|Other Error Count:"`
+    fi
+    
     if [ -n "$ERRORLINES" ] ; then
       NUMBER_OF_MEDIA_AND_OTHER_ERRORS=0
       NUMBER_OF_ERRORLINES=0


### PR DESCRIPTION
Add JBOD to Firmware state.
Add options:
--skip-offline-check for checking for dmesg, 
--disable-other-error-count for skipping check of Other Error Count (Seagate has tons of its). 
